### PR TITLE
Include post install/uninstall scripts to autocreate hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "bugs": {
     "url": "https://github.com/rossmartin/cordova-uglify/issues"
   },
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "postuninstall": "node scripts/uninstall.js"
+  }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+//After install script - installs the cordova hook into hooks/after_prepare directory
+
+//We assume after post install, this script is run from its root directory
+
+//Before
+// ./proj
+//		/hooks
+//		/node_modules
+//			/cordova-uglify
+//				/after_prepare
+//					/uglify.js
+//				/scripts
+//					install.js
+//					uninstall.js
+
+//After
+// ./proj
+//		/hooks
+//			/after_prepare
+//				uglify.js
+//		/node_modules
+//			/cordova-uglify
+//				/after_prepare
+//					uglify.js
+
+var fs = require('fs')
+var path = require('path')
+var cwd = process.cwd() //proj directory
+var scriptPath = __dirname //node_modules/cordova-uglify/scripts
+
+var paths = [ path.join(cwd, '../../hooks'), path.join(cwd, '../../hooks/after_prepare') ];
+
+for(var pathIndex in paths) {
+	if(!fs.existsSync(paths[pathIndex])) {
+		console.log('Creating directory: ', paths[pathIndex])
+		fs.mkdirSync(paths[pathIndex]);
+	}	
+}
+
+var uglifyScriptPath = path.join(cwd, 'after_prepare', 'uglify.js');
+
+var uglifyFile = fs.readFileSync(uglifyScriptPath);
+console.log('uglifyFile: ', uglifyFile)
+var uglifyAfterPreparePath = path.join(paths[1], 'uglify.js')
+
+console.log('Creating uglify hook: ', uglifyAfterPreparePath)
+fs.writeFileSync(uglifyAfterPreparePath, uglifyFile);

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+//After uninstall script to remove the uglify.js script from the users hooks/after_prepare directory
+
+var fs = require('fs')
+var path = require('path')
+var cwd = process.cwd()
+
+var uglifyJsPath = path.join(cwd, '../../', 'hooks', 'after_prepare', 'uglify.js')
+
+fs.unlink(uglifyJsPath)
+console.log('Removed: ', uglifyJsPath)


### PR DESCRIPTION
To make it easier to use cordova-uglify, include a postinstall and postuninstall script to automatically add the uglify.js file to the users ./proj_root/hooks/after_prepare directory.

https://github.com/rossmartin/cordova-uglify/issues/1
