### PR TITLE
bug fix css minification

### DIFF
--- a/after_prepare/uglify.js
+++ b/after_prepare/uglify.js
@@ -130,7 +130,7 @@ function compress(file) {
 
             source = fs.readFileSync(file, 'utf8');
             result = cssMinifier.minify(source);
-            fs.writeFileSync(file, result, 'utf8'); // overwrite the original unminified file
+            fs.writeFileSync(file, result.styles, 'utf8'); // overwrite the original unminified file
             break;
 
         case '.jpeg':


### PR DESCRIPTION
cssMinifier.minify return an object. We need to access to "styles" attribute to get CSS code.