### PR TITLE
README update --legacy-bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cordova hook that allows you to uglify or minify your apps JavaScript and CSS.  
 ## Install
 Install the following package below inside of your apps root folder.
 ```
-npm install cordova-uglify
+npm install cordova-uglify --legacy-bundling
 ```
 After install an `after_prepare` folder will be added to your `hooks` folder with the `uglify.js` script in it.  A JSON config file (`uglify-config.json`) for the script will be added to the `hooks` folder.
 


### PR DESCRIPTION
`uglify.js` is expecting dependencies in its `/node_modules/cordova-uglify/node_modules/` dir as per below:
```
var dependencyPath = path.join(cwd, 'node_modules', 'cordova-uglify', 'node_modules');
// cordova-uglify module dependencies
var UglifyJS = require(path.join(dependencyPath, 'uglify-js'));
var CleanCSS = require(path.join(dependencyPath, 'clean-css'));
var ngAnnotate = require(path.join(dependencyPath, 'ng-annotate'));
var Imagemin = require(path.join(dependencyPath, 'imagemin'));
```
But if I install `cordova-uglify` into a project that has one of those dependencies already, npm won't install those deps into the `/node_modules/cordova-uglify/node_modules/` folder, causing `uglify.js` to fail when you use `cordova prepare ios --release`. using `npm install cordova-uglify --legacy-bundling` fixes this issue.