### PR TITLE
Windows is supported

### DIFF
--- a/after_prepare/uglify.js
+++ b/after_prepare/uglify.js
@@ -52,11 +52,12 @@ function run() {
       case 'ios':
       case 'browser':
       case 'wp8':
+      case 'windows': 
         wwwPath = path.join(platformPath, platform, 'www');
         break;
 
       default:
-        console.log('this hook only supports android, ios, wp8, and browser currently');
+        console.log('this hook only supports android, ios, wp8, windows, and browser currently');
         return;
     }
 


### PR DESCRIPTION
`windows` is a supported platform now.  
https://cordova.apache.org/docs/en/latest/guide/support/

the platform name is just `windows` and it covers universal Windows apps including 10

We can add `windows` in the switch statement.  The folder structure follows `ios` `browser` `wp8`
(platforms/platformName/www)
Here is the output:

```console.log('process.env.CORDOVA_PLATFORMS: ' + process.env.CORDOVA_PLATFORMS);
process.env.CORDOVA_PLATFORMS: windows``` 