### PR TITLE
execution permissions: only chmod +x uglify.js

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -53,4 +53,4 @@ var uglifyConfigFile = fs.readFileSync(path.join(__dirname, '../uglify-config.js
 fs.writeFileSync(path.join(paths[0], 'uglify-config.json'), uglifyConfigFile);
 
 console.log('Updating hooks directory to have execution permissions...');
-shell.chmod('-R', 755, paths[0]);
+shell.chmod('-R', 'a+x', path.join(paths[1], 'uglify.js'));


### PR DESCRIPTION
When installing this package, it shouldn't change the execution permission of all the files in hooks/ but rather only uglify.js.