### PR TITLE
update clean-css to the latest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hooks"
   ],
   "dependencies": {
-    "clean-css": "3.4.8",
+    "clean-css": "4.1.19",
     "ng-annotate": "0.15.4",
     "shelljs": "^0.7.0",
     "uglify-js": "3.1.1"


### PR DESCRIPTION
Using version 3.4.8 of the clean-css, the clean-css does not handle adjacent properties needed for the iPhone X well, for example:

```
.platform-ios.platform-cordova:not(.fullscreen) .bar-header:not(.bar-subheader) > * {margin-top: 20px; margin-top: constant(safe-area-inset-top); margin-top: env(safe-area-inset-top); }
```

Version 3.4.8 of clean-css will drop "margin-top: constant(safe-area-inset-top)" required for iOS 11.0, and the CSS would be reduced to
```
.platform-ios.platform-cordova:not(.fullscreen) .bar-header:not(.bar-subheader)>*{margin-top:20px;margin-top:env(safe-area-inset-top)}
```

iOS 11.0 uses the constant() syntax, but future versions will only support env(), and therefore they should not be optimised, and therefore the expected result is:

```
.platform-ios.platform-cordova:not(.fullscreen) .bar-header:not(.bar-subheader)>*{margin-top:20px;margin-top:constant(safe-area-inset-top);margin-top:env(safe-area-inset-top)}
```

clean-css 4.1.9 does not have this issue.