### PR TITLE
Two folders added && one dependency package version upgraded && single file support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Once you have this hook installed it will compress your apps JavaScript and CSS 
     "css",
     "build", // this is needed for Ionic 2 projects
 	"cordova-js-src",
-	"plugins"
+	"plugins",
+	"cordova.js",
+	"cordova_plugins.js"
   ],
   "uglifyJsOptions": { // pass options to UglifyJS2 (you can include more than these below)
     "compress": {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Once you have this hook installed it will compress your apps JavaScript and CSS 
   "foldersToProcess": [ // when recursiveFolderSearch is set to false only files in these directories will be processed
     "js",
     "css",
-    "build" // this is needed for Ionic 2 projects
+    "build", // this is needed for Ionic 2 projects
+	"cordova-js-src",
+	"plugins"
   ],
   "uglifyJsOptions": { // pass options to UglifyJS2 (you can include more than these below)
     "compress": {

--- a/after_prepare/uglify.js
+++ b/after_prepare/uglify.js
@@ -131,7 +131,7 @@ function compress(file) {
     case '.js':
       console.log('uglifying js file ' + file);
 
-      res = ngAnnotate(String(fs.readFileSync(file)), {
+      res = ngAnnotate(String(fs.readFileSync(file, 'utf8')), {
         add: true
       });
       result = UglifyJS.minify(res.src, hookConfig.uglifyJsOptions);

--- a/after_prepare/uglify.js
+++ b/after_prepare/uglify.js
@@ -82,12 +82,19 @@ function processFolders(wwwPath) {
  * @return {undefined}
  */
 function processFiles(dir) {
+	
   fs.readdir(dir, function(err, list) {
-    if (err) {
-      console.log('processFiles err: ' + err);
+	if (err) {
+		fs.stat(dir, function(err, stat) {
+			if (!err && stat.isFile()) {
+				compress(dir);
+			} else {
+				console.log('processFiles err: ' + err);
+			}
+		});
 
-      return;
-    }
+		return;
+	}
 
     list.forEach(function(file) {
       file = path.join(dir, file);
@@ -124,7 +131,7 @@ function compress(file) {
     case '.js':
       console.log('uglifying js file ' + file);
 
-      res = ngAnnotate(String(fs.readFileSync(file, 'utf8')), {
+      res = ngAnnotate(String(fs.readFileSync(file)), {
         add: true
       });
       result = UglifyJS.minify(res.src, hookConfig.uglifyJsOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-uglify",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Cordova hook that allows you to uglify or minify your apps JavaScript and CSS.",
   "homepage": "https://github.com/rossmartin/cordova-uglify",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-uglify",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Cordova hook that allows you to uglify or minify your apps JavaScript and CSS.",
   "homepage": "https://github.com/rossmartin/cordova-uglify",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean-css": "4.1.9",
     "ng-annotate": "0.15.4",
     "shelljs": "^0.7.0",
-    "uglify-js": "3.3.16"
+    "uglify-js": "3.5.2"
   },
   "author": "Ross Martin",
   "license": "MIT",

--- a/uglify-config.json
+++ b/uglify-config.json
@@ -4,7 +4,9 @@
     "foldersToProcess": [
         "js",
         "css",
-        "build"
+        "build",
+		"cordova-js-src",
+		"plugins"
     ],
     "uglifyJsOptions": {
         "compress": {

--- a/uglify-config.json
+++ b/uglify-config.json
@@ -6,7 +6,9 @@
         "css",
         "build",
 		"cordova-js-src",
-		"plugins"
+		"plugins",
+		"cordova.js",
+		"cordova_plugins.js"
     ],
     "uglifyJsOptions": {
         "compress": {


### PR DESCRIPTION
Cordova & plugins folder added to the array (to squeeze a bit more space)
uglify-js version bump
package version bump


I'm still trying to add `cordova.js` && `cordova_plugins.js` to the `foldersToProcess` array but these are not folders, they are files and trying to use `*.js` or similar "filters" is not working.....

