### PR TITLE
update clean-css version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hooks"
   ],
   "dependencies": {
-    "clean-css": "4.1.9",
+    "clean-css": "4.2.1",
     "ng-annotate": "0.15.4",
     "shelljs": "^0.7.0",
     "uglify-js": "3.3.16"


### PR DESCRIPTION
older versions of clean-css have a regex DOS vulnerability as report by npm audit
reference: https://npmjs.com/advisories/785
change to latest patched clean-css