### PR TITLE
Convert uglify.js to node module / define in config.xml

### DIFF
--- a/after_prepare/uglify.js
+++ b/after_prepare/uglify.js
@@ -1,146 +1,134 @@
-#!/usr/bin/env node
-
 /*jshint latedef:nofunc, node:true*/
+/* eslint-env node */
 
-// Modules
-var fs = require('fs');
-var path = require('path');
-var dependencyPath = path.join(process.cwd(), 'node_modules');
-// cordova-uglify module dependencies
-var UglifyJS = require(path.join(dependencyPath, 'uglify-js'));
-var CleanCSS = require(path.join(dependencyPath, 'clean-css'));
-var ngAnnotate = require(path.join(dependencyPath, 'ng-annotate'));
+module.exports = function (ctx) {
+    "use strict";
 
-// Process
-var rootDir = process.argv[2];
-var platformPath = path.join(rootDir, 'platforms');
-var platforms = process.env.CORDOVA_PLATFORMS.split(',');
-var cliCommand = process.env.CORDOVA_CMDLINE;
+    var fs = require('fs'),
+        path = require('path'),
+        UglifyJS = require('uglify-js'),
+        CleanCSS = require('clean-css'),
+        ngAnnotate = require('ng-annotate'),
+        rootDir = ctx.opts.projectRoot,
+        platformPath = path.join(rootDir, 'platforms'),
+        platforms = ctx.opts.cordova.platforms,
+        cliCommand = ctx.cmdLine,
+        configFilePath = path.join(rootDir, 'hooks/uglify-config.json'),
+        hookConfig = JSON.parse(fs.readFileSync(configFilePath)),
+        isRelease = hookConfig.alwaysRun || (cliCommand.indexOf('--release') > -1),
+        recursiveFolderSearch = hookConfig.recursiveFolderSearch, // set this to false to manually indicate the folders to process
+        foldersToProcess = hookConfig.foldersToProcess, // add other www folders in here if needed (ex. js/controllers)
+        cssMinifier = new CleanCSS(hookConfig.cleanCssOptions);
 
-// Hook configuration
-var configFilePath = path.join(rootDir, 'hooks/uglify-config.json');
-var hookConfig = JSON.parse(fs.readFileSync(configFilePath));
-var isRelease = hookConfig.alwaysRun || (cliCommand.indexOf('--release') > -1);
-var recursiveFolderSearch = hookConfig.recursiveFolderSearch; // set this to false to manually indicate the folders to process
-var foldersToProcess = hookConfig.foldersToProcess; // add other www folders in here if needed (ex. js/controllers)
-var cssMinifier = new CleanCSS(hookConfig.cleanCssOptions);
 
-// Exit
-if (!isRelease) {
-  return;
-}
+    /**
+     * Compresses file.
+     * @param  {string} file - File path
+     * @return {undefined}
+     */
+    function compress(file) {
+        var ext = path.extname(file),
+            res,
+            source,
+            result;
 
-// Run uglifier
-run();
+        switch (ext) {
+        case '.js':
+            console.log('uglifying js file ' + file);
 
-/**
- * Run compression for all specified platforms.
- * @return {undefined}
- */
-function run() {
-  platforms.forEach(function(platform) {
-    var wwwPath;
+            res = ngAnnotate(String(fs.readFileSync(file, 'utf8')), {
+                add: true
+            });
+            result = UglifyJS.minify(res.src, hookConfig.uglifyJsOptions);
+            fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
+            break;
 
-    switch (platform) {
-      case 'android':
-        wwwPath = path.join(platformPath, platform, 'assets', 'www');
-        if (!fs.existsSync(wwwPath)) {
-          wwwPath = path.join(platformPath, platform, 'app', 'src', 'main', 'assets', 'www');
+        case '.css':
+            console.log('minifying css file ' + file);
+
+            source = fs.readFileSync(file, 'utf8');
+            result = cssMinifier.minify(source);
+            fs.writeFileSync(file, result.styles, 'utf8'); // overwrite the original unminified file
+            break;
+
+        default:
+            console.log('encountered a ' + ext + ' file, not compressing it');
+            break;
         }
-        break;
+    }
 
-      case 'ios':
-      case 'browser':
-      case 'wp8':
-      case 'windows':
-        wwwPath = path.join(platformPath, platform, 'www');
-        break;
+    /**
+     * Processes files in directories.
+     * @param  {string} dir - Directory path
+     * @return {undefined}
+     */
+    function processFiles(dir) {
+        fs.readdir(dir, function (err, list) {
+            if (err) {
+                console.log('processFiles err: ' + err);
 
-      default:
-        console.log('this hook only supports android, ios, wp8, windows, and browser currently');
+                return;
+            }
+
+            list.forEach(function (file) {
+                file = path.join(dir, file);
+
+                fs.stat(file, function (err, stat) {
+                    if (stat.isFile()) {
+                        compress(file);
+                        return;
+                    }
+
+                    if (recursiveFolderSearch && stat.isDirectory()) {
+                        processFiles(file);
+                        return;
+                    }
+                });
+            });
+        });
+    }
+
+
+    /**
+     * Processes defined folders.
+     * @param  {string} wwwPath - Path to www directory
+     * @return {undefined}
+     */
+    function processFolders(wwwPath) {
+        foldersToProcess.forEach(function (folder) {
+            processFiles(path.join(wwwPath, folder));
+        });
+    }
+    
+    
+    if (!isRelease) {
         return;
     }
+    
+    platforms.forEach(function (platform) {
+        var wwwPath;
 
-    processFolders(wwwPath);
-  });
-}
+        switch (platform) {
+        case 'android':
+            wwwPath = path.join(platformPath, platform, 'assets', 'www');
+            if (!fs.existsSync(wwwPath)) {
+                wwwPath = path.join(platformPath, platform, 'app', 'src', 'main', 'assets', 'www');
+            }
+            break;
 
-/**
- * Processes defined folders.
- * @param  {string} wwwPath - Path to www directory
- * @return {undefined}
- */
-function processFolders(wwwPath) {
-  foldersToProcess.forEach(function(folder) {
-    processFiles(path.join(wwwPath, folder));
-  });
-}
+        case 'ios':
+        case 'browser':
+        case 'wp8':
+        case 'windows':
+            wwwPath = path.join(platformPath, platform, 'www');
+            break;
 
-/**
- * Processes files in directories.
- * @param  {string} dir - Directory path
- * @return {undefined}
- */
-function processFiles(dir) {
-  fs.readdir(dir, function(err, list) {
-    if (err) {
-      console.log('processFiles err: ' + err);
-
-      return;
-    }
-
-    list.forEach(function(file) {
-      file = path.join(dir, file);
-
-      fs.stat(file, function(err, stat) {
-        if (stat.isFile()) {
-          compress(file);
-
-          return;
+        default:
+            console.log('this hook only supports android, ios, wp8, windows, and browser currently');
+            return;
         }
 
-        if (recursiveFolderSearch && stat.isDirectory()) {
-          processFiles(file);
-
-          return;
-        }
-      });
+        processFolders(wwwPath);
     });
-  });
-}
-
-/**
- * Compresses file.
- * @param  {string} file - File path
- * @return {undefined}
- */
-function compress(file) {
-  var ext = path.extname(file),
-    res,
-    source,
-    result;
-
-  switch (ext) {
-    case '.js':
-      console.log('uglifying js file ' + file);
-
-      res = ngAnnotate(String(fs.readFileSync(file, 'utf8')), {
-        add: true
-      });
-      result = UglifyJS.minify(res.src, hookConfig.uglifyJsOptions);
-      fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
-      break;
-
-    case '.css':
-      console.log('minifying css file ' + file);
-
-      source = fs.readFileSync(file, 'utf8');
-      result = cssMinifier.minify(source);
-      fs.writeFileSync(file, result.styles, 'utf8'); // overwrite the original unminified file
-      break;
-
-    default:
-      console.log('encountered a ' + ext + ' file, not compressing it');
-      break;
-  }
-}
+    
+};

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -52,5 +52,25 @@ fs.writeFileSync(uglifyAfterPreparePath, uglifyFile);
 var uglifyConfigFile = fs.readFileSync(path.join(__dirname, '../uglify-config.json'));
 fs.writeFileSync(path.join(paths[0], 'uglify-config.json'), uglifyConfigFile);
 
-console.log('Updating hooks directory to have execution permissions...');
-shell.chmod('a+x', path.join(paths[1], 'uglify.js'));
+var configFilePath = path.join(cwd, "../../", "config.xml"); // top-level config.xml
+fs.readFile(configFilePath, function (err, data) {
+    var hookNode = "\t<hook src=\"hooks/after_prepare/uglify.js\" type=\"after_prepare\" />\r\n";
+    if (err) {
+        console.log(err);
+    } else {
+        var closingNodeIdx = data.indexOf("</widget>"); // insert just before the closing node
+        if (closingNodeIdx === -1) {
+            console.log("widget node not found -- is this a config.xml file?");
+            return;
+        }
+        fs.writefile(configFilePath, (data.slice(0, closingNodeIdx) + hookNode + data.slice(closingNodeIdx)), function (err) {
+            if (err) {
+                console.log(err);
+            }
+        });
+    }
+}); // <widget>
+
+// node module - no longer requires execute permissions
+//console.log('Updating hooks directory to have execution permissions...');
+//shell.chmod('a+x', path.join(paths[1], 'uglify.js'));

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -27,7 +27,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var shell = require('shelljs');
 var cwd = process.cwd(); // $(project)/node_modules/cordova-uglify
 // __dirname = $(project)/node_modules/cordova-uglify/scripts
 
@@ -70,7 +69,3 @@ fs.readFile(configFilePath, function (err, data) {
         });
     }
 }); // <widget>
-
-// node module - no longer requires execute permissions
-//console.log('Updating hooks directory to have execution permissions...');
-//shell.chmod('a+x', path.join(paths[1], 'uglify.js'));


### PR DESCRIPTION
This is a larger change:

- Refactored the uglify.js script to be a node module with a module.exports function definition.
- Reworked the install.js script to add a `<hook>` definition at the end of the `config.xml` widget block, and remove the code that makes the uglify.js script executable.

Tested locally on iOS and Android, but I wouldn't mind another pair (or more!) of eyes checking things over to make sure I've changed things in the right location. Thanks again for providing this plugin!